### PR TITLE
Add sync.yml files

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -1,0 +1,3 @@
+SymbiFlow/prjxray-bram-patch:
+  - CODE_OF_CONDUCT.md
+  - CONTRIBUTING.md

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,18 @@
+name: Sync Files
+on:
+  push:
+    branches:
+      - main
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+
+      - name: Run Repo File Sync
+        uses: BetaHuhn/repo-file-sync-action@v1.16.0
+        with:
+          GH_PAT: ${{ secrets.GH_PAT }}
+          COMMIT_BODY: "Signed-off-by: common-config-bot"
+          FORK: common-config-bot


### PR DESCRIPTION
This pull request will not function without a PAT added the the repository, but it serves to demo what such a workflow could look like, as requested in [issue 7](https://github.com/SymbiFlow/symbiflow-common-config/issues/7#issuecomment-992322297).

The actual syncing is all done by the [BetaHuhn/repo-file-sync-action](https://github.com/marketplace/actions/repo-file-sync-action). In addition to including it as a step in the workflow, an additional file is also necessary to list what repositories and files should be kept in sync. The default location of this file is `.github/sync.yml`

I've included only `SymbiFlow/prjxray-bram-patch` for now, as that was the test repository decided upon, but it would be easy to add others and customize what we sync to them later on.

When the action runs, all of the target repositories listed in `.github/sync.yml` will be forked by the account listed under the `FORK` parameter, then after all of the files are synced on a new branch, a pull request is opened to the upstream repository listed in `.github/sync.yml`. This way, even with the PAT to the bot account, the action cannot modify the upstream repositories.