### PR TITLE
Add email to commit body

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -14,5 +14,5 @@ jobs:
         uses: BetaHuhn/repo-file-sync-action@v1.16.0
         with:
           GH_PAT: ${{ secrets.GH_PAT }}
-          COMMIT_BODY: "Signed-off-by: common-config-bot"
+          COMMIT_BODY: "Signed-off-by: common-config-bot <common.config.bot@gmail.com>"
           FORK: common-config-bot


### PR DESCRIPTION
Adds email address of bot account to each commit body `symbiflow-common-config` will generate.
 
Fixes  [PR #52](https://github.com/SymbiFlow/prjxray-bram-patch/pull/52)

Signed-off-by: Xan Johnson <xanjohns@gmail.com>