### PR TITLE
Add git username and email

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -16,3 +16,5 @@ jobs:
           GH_PAT: ${{ secrets.GH_PAT }}
           COMMIT_BODY: "Signed-off-by: common-config-bot <common.config.bot@gmail.com>"
           FORK: common-config-bot
+          GIT_USERNAME: common-config-bot
+          GIT_EMAIL: common.config.bot@gmail.com


### PR DESCRIPTION
Adds `GIT_USERNAME` and `GIT_EMAIL` to fix DCO signoffs.

Signed-off-by: Xan Johnson <xanjohns@gmail.com>