### PR TITLE
Add repositories to sync to

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -1,12 +1,13 @@
 group:
   - repos:
-      - SymbiFlow/prjxray-bram-patch
-      - SymbiFlow/symbiflow-arch-defs
-      - SymbiFlow/prjxray
-      - SymbiFlow/symbiflow-examples
       - SymbiFlow/fasm
       - SymbiFlow/prjuray
+      - SymbiFlow/prjxray
+      - SymbiFlow/prjxray-bram-patch
       - SymbiFlow/python-symbiflow-v2x
+      - SymbiFlow/symbiflow-arch-defs
+      - SymbiFlow/symbiflow-examples
+      - SymbiFlow/yosys-symbiflow-plugins
     files:
       - CODE_OF_CONDUCT.md
       - CONTRIBUTING.md

--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -1,6 +1,12 @@
 group:
-  - repos: |
-      SymbiFlow/prjxray-bram-patch
+  - repos:
+      - SymbiFlow/prjxray-bram-patch
+      - SymbiFlow/symbiflow-arch-defs
+      - SymbiFlow/prjxray
+      - SymbiFlow/symbiflow-examples
+      - SymbiFlow/fasm
+      - SymbiFlow/prjuray
+      - SymbiFlow/python-symbiflow-v2x
     files:
       - CODE_OF_CONDUCT.md
       - CONTRIBUTING.md


### PR DESCRIPTION
Adds a variety of repositories that will start syncing with `symbiflow-common-config`. 

Signed-off-by: Xan Johnson <xanjohns@gmail.com>