### PR TITLE
Add basic templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE-BUG.md
+++ b/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE-BUG.md
@@ -1,0 +1,37 @@
+---
+name: Bug Report
+title: Bug Report
+about: A standard issue template to use in all Symbiflow repositories. Adapted from Open Source Templates by Tal Ater. 
+labels: bug
+---
+<!--- Provide a general summary of the issue in the Title above -->
+
+## Description
+<!--- Provide a more detailed introduction to the issue itself, and why you consider it to be a bug -->
+
+## Expected Behavior
+<!--- Tell us what should happen -->
+
+## Actual Behavior
+<!--- Tell us what happens instead -->
+
+## Possible Fix
+<!--- Not obligatory, but suggest a fix or reason for the bug -->
+
+## Steps to Reproduce
+<!--- Provide a link to a live example, or an unambiguous set of steps to -->
+<!--- reproduce this bug. Include code to reproduce, if relevant -->
+1.
+2.
+3.
+4.
+
+## Context
+<!--- How has this bug affected you? What were you trying to accomplish? -->
+
+## Your Environment
+<!--- Include as many relevant details about the environment you experienced the bug in -->
+* Version used:
+* Operating System and version:
+* Link to your project:
+

--- a/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE-FEATURE.md
+++ b/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE-FEATURE.md
@@ -1,0 +1,23 @@
+---
+name: New Feature/Improvement
+about: A standard issue template to use in all Symbiflow repositories. Adapted from Open Source Templates by Tal Ater. 
+labels: enhancement
+---
+<!--- Provide a general summary of the issue in the Title above -->
+
+## Detailed Description
+<!--- Provide a detailed description of the change or addition you are proposing -->
+
+## Context
+<!--- Why is this change important to you? How would you use it? -->
+<!--- How can it benefit other users? -->
+
+## Possible Implementation
+<!--- Not obligatory, but suggest an idea for implementing addition or change -->
+
+## Your Environment
+<!--- Include as many relevant details about the environment you experienced the bug in -->
+* Version used:
+* Operating System and version:
+* Link to your project:
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+<!--- A standard pull request template to use for all Symbiflow repositories. Adapted from Open Source Templates(https://www.talater.com/open-source-templates/#/) by Tal Ater. -->
+
+<!--- Provide a general summary of your changes in the Title above -->
+
+## Description
+<!--- Describe your changes in detail -->
+
+## Motivation and Context
+<!--- Why is this change required? What problem does it solve? -->
+<!--- If it fixes an open issue, please link to the issue here. -->
+
+## How Has This Been Tested?
+<!--- Please describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, and the tests you ran to -->
+<!--- see how your change affects other areas of the code, etc. -->
+
+## Types of changes
+<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+
+## Checklist:
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+- [ ] My code follows the code style of this project.
+- [ ] My change requires a change to the documentation.
+- [ ] I have updated the documentation accordingly.
+- [ ] I have read the **CONTRIBUTING** document.
+- [ ] I have added tests to cover my changes.
+- [ ] All new and existing tests passed.


### PR DESCRIPTION
Add a starter template for pull requests and two different issue templates.

I've included quite a bit of information on each template just to show some options, but if we'd prefer something simpler, that works too.

Once these files begin syncing with other repositories, these templates will automatically be used any time someone opens a pull request/issue on the repositories.

Signed-off-by: Xan Johnson <xanjohns@gmail.com>